### PR TITLE
ping issue: preserve xattr info

### DIFF
--- a/jobs/cflinuxfs4-rootfs-setup/templates/pre-start
+++ b/jobs/cflinuxfs4-rootfs-setup/templates/pre-start
@@ -10,7 +10,7 @@ CA_DIR=$ROOTFS_DIR/usr/local/share/ca-certificates/
 
 if [ ! -d $ROOTFS_DIR ]; then
   mkdir -p $ROOTFS_DIR
-  tar -pzxf $ROOTFS_PACKAGE/cflinuxfs4.tar.gz -C $ROOTFS_DIR
+  tar --xattrs --xattrs-include='*' -pzxf $ROOTFS_PACKAGE/cflinuxfs4.tar.gz -C $ROOTFS_DIR
 fi
 
 if grep -q "trusted_ca_certificates" $TRUSTED_CERT_FILE; then
@@ -46,5 +46,5 @@ fi
 # change modification time to invalidate garden's image cache
 touch $ROOTFS_DIR
 
-tar -C $ROOTFS_DIR -cf $ROOTFS_TAR .
+tar --xattrs --xattrs-include='*' -C $ROOTFS_DIR -cf $ROOTFS_TAR .
 rm -rf $ROOTFS_DIR


### PR DESCRIPTION
This bosh-release untars and retars the rootFS to update ca certs, but in the process did not preserve xattr information.

With this commit, on tar operations xattr attributes are preserved which are required for linux file capabilities[1].
The issue was found while investigating why newer versions of the iputils-ping that rely on capabilities (instead of setuid in older versions) weren't working as expected.

This change along with a similar change in garden[2] fixes the ping issue on CF. The setuid workaround[3] is not required anymore.

1. https://man7.org/linux/man-pages/man7/capabilities.7.html#:~:text=a%20capability%20set.-,File%20capabilities,-Since%20Linux%202.6.24
2. https://github.com/cloudfoundry/guardian/pull/420 available in garden-runc-release 1.39.0
3. https://github.com/cloudfoundry/cflinuxfs4/pull/13

Also see discussion https://cloudfoundry.slack.com/archives/C033RE5D6/p1694194745658319
Older related PR: https://github.com/cloudfoundry/cflinuxfs4-release/pull/4